### PR TITLE
Feature / UseURL: open file in workspace

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+	"semi": true,
+	"singleQuote": true,
+	"trailingComma": "all",
+	"printWidth": 120
+}

--- a/README.md
+++ b/README.md
@@ -15,9 +15,23 @@ The icons work with light and dark mode.
 You can also use it as a command and assign hotkeys to it. You can disable the ribbon button in settings.
 ![command](https://user-images.githubusercontent.com/5298006/125869408-d39d870b-ab4f-42d0-b915-b6abc1e617d5.png)
 
-By default the plugin uses `child_process` to launch VSCode with the `code` command, but the previous method using URLs can still be enabled.
+## Settings
+
+### Default template for executing the `code` command
+
+By default the plugin uses `child_process` to launch VSCode with the `code` command, but the previous method using URLs can still be enabled by checking the following option:
+
+### Open VSCode using a `vscode://` URL instead of executing the `code` command.
+
+On some systems, this may be faster than using the `child_process` approach.
+
+### Default template for executing the `code` command
 
 You can template the command opening VSCode however you like with its [provided command line arguments](https://code.visualstudio.com/docs/editor/command-line). This way you can technically launch any command you set, so take caution. Potential use cases include opening workspaces with `.code-workspace` files (e.g. for Dendron), opening specific files, folders, etc.
+
+Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code").
+
+Example of loading a file using VSCode: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`.
 
 ## Installation
 
@@ -26,7 +40,7 @@ You can also manually copy from releases to your `.obsidian/plugins/open-vscode`
 
 ## Caveats
 
-When you use the URL method for opening, VSCode can't open a workspace without a further confirmation dialog (that you just can hit enter on) for security reasons. See [this issue](https://github.com/microsoft/vscode/issues/95670) for more infomation.
+The first time you use the URL method for opening, VSCode displays a confirmation dialog (that you just can hit enter on) for security reasons. See [this issue](https://github.com/microsoft/vscode/issues/95670) for more infomation.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Note that on MacOS, a full path to the VSCode executable is required (generally 
 
 Example of loading a file using VSCode: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`.
 
+### Path to VSCode Workspace
+
+If "Use URL" is checked, VSCode will open Obsidian files in this workspace (requires an absolute path).
+
+### Open file
+
+If "Use URL" is checked, open the current file rather than the root of the Obsidian vault.
+
 ## Installation
 
 You can install the plugin via the Community Plugins tab within Obsidian.

--- a/main.ts
+++ b/main.ts
@@ -32,20 +32,24 @@ export default class OpenVSCode extends Plugin {
 		if (!(this.app.vault.adapter instanceof FileSystemAdapter)) {
 			return;
 		}
+		const { executeTemplate, useURL } = this.settings;
 
 		const path = this.app.vault.adapter.getBasePath();
-		if (this.settings.useURL) {
+		const file = this.app.workspace.getActiveFile();
+		const filePath = file?.path ?? '';
+
+		if (useURL) {
 			const url = "vscode://file/" + path;
 			console.log('[openVSCode]', { url });
 			window.open(url, "_blank");
 		}
 		else {
 			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const { exec } = require("child_process");
-			const file = this.app.workspace.getActiveFile();
-			let command = this.settings.executeTemplate.trim() === "" ? DEFAULT_SETTINGS.executeTemplate : this.settings.executeTemplate;
-			command = replaceAll(command, "{{vaultpath}}", path);
-			command = replaceAll(command, "{{filepath}}", file?.path ?? "");
+			const { exec } = require('child_process');
+
+			let command = executeTemplate.trim() === '' ? DEFAULT_SETTINGS.executeTemplate : executeTemplate;
+			command = replaceAll(command, '{{vaultpath}}', path);
+			command = replaceAll(command, '{{filepath}}', filePath);
 			console.log('[openVSCode]', { command });
 			exec(command, (error: never, stdout: never, stderr: never) => {
 				if (error) {

--- a/main.ts
+++ b/main.ts
@@ -112,7 +112,9 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 			);
 		new Setting(containerEl)
 			.setName('Use URL')
-			.setDesc('Open VSCode using a `vscode://` URL instead of executing the `code` command.')
+			.setDesc(
+				'Open VSCode using a `vscode://` URL instead of executing the `code` command. Opening via URL may be faster than the alternative on some systems.'
+			)
 			.addToggle((toggle) => toggle
 				.setValue(this.plugin.settings.useURL)
 				.onChange((value) => {
@@ -122,7 +124,9 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 			);
 		new Setting(containerEl)
 			.setName('Default template for executing the `code` command')
-			.setDesc('You can use the following variables: {{vaultpath}}, {{filepath}} (relative)')
+			.setDesc(
+				'You can use the following variables: `{{vaultpath}}`, `{{filepath}}` (relative). Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code"). Example: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`'
+			)
 			.addText(text => text.setPlaceholder(DEFAULT_SETTINGS.executeTemplate)
 				.setValue(this.plugin.settings.executeTemplate || DEFAULT_SETTINGS.executeTemplate)
 				.onChange((value) => {

--- a/main.ts
+++ b/main.ts
@@ -82,7 +82,7 @@ interface OpenVSCodeSettings {
 const DEFAULT_SETTINGS: OpenVSCodeSettings = {
 	ribbonIcon: true,
 	useURL: false,
-	executeTemplate: "code \"{{vaultpath}}\"",
+	executeTemplate: 'code "{{vaultpath}}/{{filepath}}"',
 }
 
 class OpenVSCodeSettingsTab extends PluginSettingTab {

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,10 @@
-import {
-	addIcon, App, FileSystemAdapter, Plugin,
-	PluginSettingTab, Setting
-} from 'obsidian';
+import { App, FileSystemAdapter, Plugin, PluginSettingTab, Setting, addIcon } from 'obsidian';
 
 const svg = `
 <path
   fill="currentColor"
   d="M 96.453125 10.773438 L 75.882812 0.878906 C 73.488281 -0.277344 70.640625 0.210938 68.769531 2.082031 L 29.367188 38.035156 L 12.195312 25.011719 C 10.601562 23.789062 8.351562 23.890625 6.871094 25.242188 L 1.371094 30.253906 C -0.449219 31.898438 -0.449219 34.761719 1.355469 36.40625 L 16.25 49.996094 L 1.355469 63.585938 C -0.449219 65.230469 -0.449219 68.097656 1.371094 69.742188 L 6.871094 74.753906 C 8.367188 76.101562 10.601562 76.203125 12.195312 74.980469 L 29.367188 61.945312 L 68.789062 97.914062 C 70.644531 99.785156 73.492188 100.273438 75.882812 99.117188 L 96.476562 89.203125 C 98.640625 88.164062 100.007812 85.980469 100.007812 83.570312 L 100.007812 16.398438 C 100.007812 14.007812 98.621094 11.808594 96.460938 10.769531 Z M 75.015625 72.707031 L 45.101562 50 L 75.015625 27.292969 Z M 75.015625 72.707031"
-/>`
+/>`;
 
 addIcon('vscode-logo', svg);
 export default class OpenVSCode extends Plugin {
@@ -24,7 +21,7 @@ export default class OpenVSCode extends Plugin {
 		this.addCommand({
 			id: 'open-vscode',
 			name: 'Open as Visual Studio Code workspace',
-			callback: this.openVSCode.bind(this)
+			callback: this.openVSCode.bind(this),
 		});
 	}
 
@@ -59,8 +56,7 @@ export default class OpenVSCode extends Plugin {
 				console.log('[openVSCode]', { url });
 				window.open(url);
 			}, timeout);
-		}
-		else {
+		} else {
 			// eslint-disable-next-line @typescript-eslint/no-var-requires
 			const { exec } = require('child_process');
 
@@ -91,13 +87,13 @@ export default class OpenVSCode extends Plugin {
 				this.openVSCode();
 			});
 		}
-	}
+	};
 }
 
 interface OpenVSCodeSettings {
-	ribbonIcon: boolean,
-	useURL: boolean,
-	executeTemplate: string,
+	ribbonIcon: boolean;
+	useURL: boolean;
+	executeTemplate: string;
 	workspacePath: string;
 	openFile: boolean;
 }
@@ -108,10 +104,9 @@ const DEFAULT_SETTINGS: OpenVSCodeSettings = {
 	executeTemplate: 'code "{{vaultpath}}/{{filepath}}"',
 	workspacePath: '',
 	openFile: true,
-}
+};
 
 class OpenVSCodeSettingsTab extends PluginSettingTab {
-
 	plugin: OpenVSCode;
 
 	constructor(app: App, plugin: OpenVSCode) {
@@ -122,70 +117,71 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
-		containerEl.createEl("h2", { text: "Settings" });
+		containerEl.createEl('h2', { text: 'Settings' });
 
 		new Setting(containerEl)
 			.setName('Ribbon Icon')
 			.setDesc('Turn on if you want to have a Ribbon Icon.')
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.ribbonIcon)
-				.onChange((value) => {
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.ribbonIcon).onChange((value) => {
 					this.plugin.settings.ribbonIcon = value;
 					this.plugin.saveSettings();
 					this.plugin.refreshIconRibbon();
-				})
+				}),
 			);
 		new Setting(containerEl)
 			.setName('Use URL')
 			.setDesc(
-				'Open VSCode using a `vscode://` URL instead of executing the `code` command. Opening via URL may be faster than the alternative on some systems.'
+				'Open VSCode using a `vscode://` URL instead of executing the `code` command. Opening via URL may be faster than the alternative on some systems.',
 			)
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.useURL)
-				.onChange((value) => {
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.useURL).onChange((value) => {
 					this.plugin.settings.useURL = value;
 					this.plugin.saveSettings();
-				})
+				}),
 			);
 		new Setting(containerEl)
 			.setName('Default template for executing the `code` command')
 			.setDesc(
-				'You can use the following variables: `{{vaultpath}}`, `{{filepath}}` (relative). Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code"). Example: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`'
+				'You can use the following variables: `{{vaultpath}}`, `{{filepath}}` (relative). Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code"). Example: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`',
 			)
-			.addText(text => text.setPlaceholder(DEFAULT_SETTINGS.executeTemplate)
-				.setValue(this.plugin.settings.executeTemplate || DEFAULT_SETTINGS.executeTemplate)
-				.onChange((value) => {
-					value = value.trim();
-					if (value === "") value = DEFAULT_SETTINGS.executeTemplate;
-					this.plugin.settings.executeTemplate = value;
-					this.plugin.saveData(this.plugin.settings);
-				}));
+			.addText((text) =>
+				text
+					.setPlaceholder(DEFAULT_SETTINGS.executeTemplate)
+					.setValue(this.plugin.settings.executeTemplate || DEFAULT_SETTINGS.executeTemplate)
+					.onChange((value) => {
+						value = value.trim();
+						if (value === '') value = DEFAULT_SETTINGS.executeTemplate;
+						this.plugin.settings.executeTemplate = value;
+						this.plugin.saveData(this.plugin.settings);
+					}),
+			);
 		new Setting(containerEl)
-					.setName('Path to VSCode Workspace (Use URL only)')
-					.setDesc(
-						'If "Use URL" is checked, VSCode will open Obsidian files in this workspace (requires an absolute path)',
-					)
-					.addText((text) =>
-						text
-							.setPlaceholder(DEFAULT_SETTINGS.workspacePath)
-							.setValue(this.plugin.settings.workspacePath || DEFAULT_SETTINGS.workspacePath)
-							.onChange((value) => {
-								value = value.trim();
-								if (value === '') value = DEFAULT_SETTINGS.workspacePath;
-								this.plugin.settings.workspacePath = value;
-								this.plugin.saveData(this.plugin.settings);
-							}),
-					);
+			.setName('Path to VSCode Workspace (Use URL only)')
+			.setDesc(
+				'If "Use URL" is checked, VSCode will open Obsidian files in this workspace (requires an absolute path)',
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(DEFAULT_SETTINGS.workspacePath)
+					.setValue(this.plugin.settings.workspacePath || DEFAULT_SETTINGS.workspacePath)
+					.onChange((value) => {
+						value = value.trim();
+						if (value === '') value = DEFAULT_SETTINGS.workspacePath;
+						this.plugin.settings.workspacePath = value;
+						this.plugin.saveData(this.plugin.settings);
+					}),
+			);
 
-				new Setting(containerEl)
-					.setName('Open current file (Use URL only)')
-					.setDesc('If "Use URL" is checked, open the current file rather than the root of the vault')
-					.addToggle((toggle) =>
-						toggle.setValue(this.plugin.settings.openFile || DEFAULT_SETTINGS.openFile).onChange((value) => {
-							this.plugin.settings.openFile = value;
-							this.plugin.saveData(this.plugin.settings);
-						}),
-					);
+		new Setting(containerEl)
+			.setName('Open current file (Use URL only)')
+			.setDesc('If "Use URL" is checked, open the current file rather than the root of the vault')
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.openFile || DEFAULT_SETTINGS.openFile).onChange((value) => {
+					this.plugin.settings.openFile = value;
+					this.plugin.saveData(this.plugin.settings);
+				}),
+			);
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,7 @@ export default class OpenVSCode extends Plugin {
 	settings: OpenVSCodeSettings;
 
 	async onload() {
+		console.log('Loading ' + this.manifest.name + ' plugin');
 		this.addSettingTab(new OpenVSCodeSettingsTab(this.app, this));
 		await this.loadSettings();
 
@@ -35,6 +36,7 @@ export default class OpenVSCode extends Plugin {
 		const path = this.app.vault.adapter.getBasePath();
 		if (this.settings.useURL) {
 			const url = "vscode://file/" + path;
+			console.log('[openVSCode]', { url });
 			window.open(url, "_blank");
 		}
 		else {
@@ -44,6 +46,7 @@ export default class OpenVSCode extends Plugin {
 			let command = this.settings.executeTemplate.trim() === "" ? DEFAULT_SETTINGS.executeTemplate : this.settings.executeTemplate;
 			command = replaceAll(command, "{{vaultpath}}", path);
 			command = replaceAll(command, "{{filepath}}", file?.path ?? "");
+			console.log('[openVSCode]', { command });
 			exec(command, (error: never, stdout: never, stderr: never) => {
 				if (error) {
 					console.error(`exec error: ${error}`);


### PR DESCRIPTION
Thanks for the plugin!

- I've documented the requirement to use the full path to `code` on MacOS #3 
- **I changed the default template to "Open file"** which might be a bit cheeky, but it seems the logical behaviour to me (principle of least surprise). It's in a separate commit, so easy to remove if you disapprove!
- I've found that UseURL is noticeably faster on my machine, so I added that note to the readme and settings (the default is still `child_process.exec`)
- Due to the above, I've added two new checkboxes which facilitate opening the current file in your defined VSCode workspace in the case that you're using UseURL

Additionally, I added a prettier config that matched the original as closely as I could (it wasn't consistent) bc I was fighting the editor. Wasn't clear on how you were building, as I see that your dist is generated by rollup, whereas what's in this repo compiles with esbuild... works a treat, regardless!

HTH, ptim

![screenshot - test vault - Obsidian v0 14 2 - 2022-03-28 at 16 01](https://user-images.githubusercontent.com/218044/160331048-15660fbd-8632-4882-b345-9a191747d9f7.png)

