### PR TITLE
Move `open-in-vscode-via-url` to a separate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Open in VSCode
 
-This plugin for [Obsidian](https://obsidian.md/) makes a ribbon button and a command to open your vault as a Visual Studio Code workspace.
+This plugin for [Obsidian](https://obsidian.md/) makes a ribbon button and two commands to open your vault as a Visual Studio Code workspace:
+
+-   `open-vscode`: Uses `child_process` to launch VSCode with the `code` command. Currently, this is the command bound to the ribbon button.
+-   `open-vscode-via-url`: Open VSCode using a `vscode://` URL
 
 It's functionality is probably made redundant now using the [Shell commands](https://github.com/Taitava/obsidian-shellcommands) and [Customizable Sidebar](https://github.com/phibr0/obsidian-customizable-sidebar) (or [Buttons](https://github.com/shabegom/buttons)) plugins, but it'll be maintained for the foreseeable future.
 
@@ -17,14 +20,6 @@ You can also use it as a command and assign hotkeys to it. You can disable the r
 
 ## Settings
 
-### Open VSCode by executing the `code` command
-
-By default the plugin uses `child_process` to launch VSCode with the `code` command, but the previous method using URLs can still be enabled by checking the following option:
-
-### Open VSCode using a `vscode://` URL instead of executing the `code` command.
-
-On some systems, this may be faster than using the `child_process` approach.
-
 ### Template for executing the `code` command
 
 You can template the command opening VSCode however you like with its [provided command line arguments](https://code.visualstudio.com/docs/editor/command-line). This way you can technically launch any command you set, so take caution. Potential use cases include opening workspaces with `.code-workspace` files (e.g. for Dendron), opening specific files, folders, etc.
@@ -34,28 +29,38 @@ Note that on MacOS, a full path to the VSCode executable is required (generally 
 You can use the following variables: `{{vaultpath}}` (absolute), `{{filepath}}` (relative).
 The default template is `code "{{vaultpath}}" "{{vaultpath}}/{{filepath}}"`, which opens the current file (if there is one) in the workspace that is the vault's root folder. This gets expanded to be executed in your shell as `code "C:\Users\YourUser\Documents\vault" "C:\Users\YourUser\Documents\vault/Note.md"`, for example.
 
-### Path to VSCode Workspace
+### Settings for `open-vscode-via-url`
 
-If "Use URL" is checked, VSCode will open Obsidian files in this workspace (requires an absolute path).
+On some systems, this may be faster than using the `child_process` approach.
 
-### Open file
+-   **Open file**
 
-If "Use URL" is checked, open the current file rather than the root of the Obsidian vault.
+    Open the current file rather than the root of the Obsidian vault.
+
+-   **Path to VSCode Workspace**
+
+    Defaults to the {{vaultpath}} template variable. You can set this to an absolute
+    path to a ".code-workspace" file if you prefer to use a Multi Root workspace
+    file: https://code.visualstudio.com/docs/editor/workspaces#_multiroot-workspaces
+
+-   **Open VSCode using a `vscode-insiders://` URL**
+
+The first time you use the URL method for opening, VSCode displays a confirmation dialog (that you just can hit enter on) for security reasons. See [this issue](https://github.com/microsoft/vscode/issues/95670) for more infomation.
 
 ## Installation
 
 You can install the plugin via the Community Plugins tab within Obsidian.
 You can also manually copy from releases to your `.obsidian/plugins/open-vscode` folder.
 
-## Caveats
-
-The first time you use the URL method for opening, VSCode displays a confirmation dialog (that you just can hit enter on) for security reasons. See [this issue](https://github.com/microsoft/vscode/issues/95670) for more infomation.
-
 ## Development
 
-Run `npm install` for dependencies and `npm run build` to build.
+Run `npm install` for dependencies and `npm run dev` to build and watch files.
 
 This plugin follows the structure of the [Obsidian Sample Plugin](https://github.com/obsidianmd/obsidian-sample-plugin), see further details there. Contributions are welcome.
+
+If [pjeby/hot-reload](https://github.com/pjeby/hot-reload) is installed,
+activated, and open-vscode is registered with hot-reload, then extra logging
+and DX commands to refresh settings are activated.
 
 ## Credits
 

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,4 @@
+import { runInThisContext } from 'vm';
 import { App, FileSystemAdapter, Plugin, PluginSettingTab, Setting, addIcon } from 'obsidian';
 
 const svg = `
@@ -7,6 +8,18 @@ const svg = `
 />`;
 
 addIcon('vscode-logo', svg);
+
+type AppWithPlugins = App & {
+	plugins: {
+		disablePlugin: (id: string) => {};
+		enablePlugin: (id: string) => {};
+		enabledPlugins: Set<string>;
+		plugins: Record<string, any>;
+	};
+};
+
+let DEV: boolean = false;
+
 export default class OpenVSCode extends Plugin {
 	ribbonIcon: HTMLElement;
 	settings: OpenVSCodeSettings;
@@ -23,6 +36,36 @@ export default class OpenVSCode extends Plugin {
 			name: 'Open as Visual Studio Code workspace',
 			callback: this.openVSCode.bind(this),
 		});
+
+		DEV =
+			(this.app as AppWithPlugins).plugins.enabledPlugins.has('hot-reload') &&
+			(this.app as AppWithPlugins).plugins.plugins['hot-reload'].enabledPlugins.has(this.manifest.id);
+
+		if (DEV) {
+			this.addCommand({
+				id: 'open-vscode-reload',
+				name: 'Reload the plugin in dev',
+				callback: this.reload.bind(this),
+			});
+		}
+	}
+
+	/**
+	 * [pjeby](https://forum.obsidian.md/t/how-to-get-started-with-developing-a-custom-plugin/8157/7)
+	 *
+	 * > Of course, while doing development, you may need to reload your plugin
+	 * > after making changes. You can do this by reloading, sure, but it’s easier
+	 * > to just go to settings and then toggle the plugin off, then back on again.
+	 * >
+	 * > You can also automate this process from within the plugin itself, by
+	 * > including a command that does something like this:
+	 */
+	async reload() {
+		const id = this.manifest.id;
+		const plugins = (this.app as AppWithPlugins).plugins;
+		await plugins.disablePlugin(id);
+		await plugins.enablePlugin(id);
+		console.log('[open-vscode] reloaded', this);
 	}
 
 	async openVSCode() {

--- a/main.ts
+++ b/main.ts
@@ -171,10 +171,10 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
-		containerEl.createEl('h2', { text: 'Settings' });
+		containerEl.createEl('h3', { text: 'General settings' });
 
 		new Setting(containerEl)
-			.setName('Ribbon Icon')
+			.setName('Display Ribbon Icon')
 			.setDesc('Turn on if you want to have a Ribbon Icon.')
 			.addToggle((toggle) =>
 				toggle.setValue(this.plugin.settings.ribbonIcon).onChange((value) => {
@@ -194,6 +194,9 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				}),
 			);
+
+		containerEl.createEl('h3', { text: 'Open via `code` CLI settings' });
+
 		new Setting(containerEl)
 			.setName('Template for executing the `code` command')
 			.setDesc(
@@ -210,6 +213,9 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 						this.plugin.saveData(this.plugin.settings);
 					}),
 			);
+
+		containerEl.createEl('h3', { text: 'Open via `vscode://` URL settings' });
+
 		new Setting(containerEl)
 			.setName('Path to VSCode Workspace (Use URL only)')
 			.setDesc(

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,3 @@
-import { runInThisContext } from 'vm';
 import { App, FileSystemAdapter, Plugin, PluginSettingTab, Setting, addIcon } from 'obsidian';
 
 const svg = `
@@ -46,6 +45,12 @@ export default class OpenVSCode extends Plugin {
 				id: 'open-vscode-reload',
 				name: 'Reload the plugin in dev',
 				callback: this.reload.bind(this),
+			});
+
+			this.addCommand({
+				id: 'open-vscode-reset-settings',
+				name: 'Reset plugins settings to default in dev',
+				callback: this.resetSettings.bind(this),
 			});
 		}
 	}
@@ -120,6 +125,12 @@ export default class OpenVSCode extends Plugin {
 	}
 
 	async saveSettings() {
+		await this.saveData(this.settings);
+	}
+
+	async resetSettings() {
+		console.log('[open-vscode]', { old: this.settings, DEFAULT_SETTINGS });
+		this.settings = DEFAULT_SETTINGS;
 		await this.saveData(this.settings);
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -200,7 +200,7 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Template for executing the `code` command')
 			.setDesc(
-				'You can use the following variables: `{{vaultpath}} (absolute)`, `{{filepath}}` (relative). Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code"). Example: `/usr/local/bin/code {{vaultpath}}/{{filepath}}`',
+				'You can use the following variables: `{{vaultpath}}` (absolute), `{{filepath}}` (relative). Note that on MacOS, a full path to the VSCode executable is required (generally "/usr/local/bin/code"). Example: `/usr/local/bin/code "{{vaultpath}}" "{{vaultpath}}/{{filepath}}"`',
 			)
 			.addText((text) =>
 				text

--- a/main.ts
+++ b/main.ts
@@ -107,7 +107,7 @@ export default class OpenVSCode extends Plugin {
 		if (!(this.app.vault.adapter instanceof FileSystemAdapter)) {
 			return;
 		}
-		const { openFile } = this.settings;
+		const { openFile, useUrlInsiders } = this.settings;
 
 		const path = this.app.vault.adapter.getBasePath();
 		const file = this.app.workspace.getActiveFile();
@@ -120,7 +120,8 @@ export default class OpenVSCode extends Plugin {
 			});
 
 		// https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls
-		let url = `vscode://file/${path}`;
+		const protocol = useUrlInsiders ? 'vscode-insiders://' : 'vscode://';
+		let url = `${protocol}file/${path}`;
 
 		if (openFile) {
 			url += `/${filePath}`;
@@ -180,6 +181,7 @@ interface OpenVSCodeSettings {
 	executeTemplate: string;
 	openFile: boolean;
 	workspacePath: string;
+	useUrlInsiders: boolean;
 }
 
 const DEFAULT_SETTINGS: OpenVSCodeSettings = {
@@ -187,6 +189,7 @@ const DEFAULT_SETTINGS: OpenVSCodeSettings = {
 	executeTemplate: 'code "{{vaultpath}}" "{{vaultpath}}/{{filepath}}"',
 	openFile: true,
 	workspacePath: '{{vaultpath}}',
+	useUrlInsiders: false,
 };
 
 class OpenVSCodeSettingsTab extends PluginSettingTab {
@@ -272,6 +275,13 @@ class OpenVSCodeSettingsTab extends PluginSettingTab {
 			}),
 		);
 		workspacePathDescEl.appendText('.');
+
+		new Setting(containerEl).setName('Open VSCode using a `vscode-insiders://` URL').addToggle((toggle) => {
+			toggle.setValue(this.plugin.settings.useUrlInsiders).onChange((value) => {
+				this.plugin.settings.useUrlInsiders = value;
+				this.plugin.saveSettings();
+			});
+		});
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/NomarCub/obsidian-open-vscode/pull/5

Hi @NomarCub ! Many apologies for the very slow reply...

The changes somehow appear more sweeping than I originally intended, but I think it's for the best - the commits are granular, so if anything rubs you up the wrong way (eg - hope you don't mind the dev helpers), let me know and I can adjust / remove!

I'm not sure why this PR is "Can't automatically merge".. it merged cleanly on my fork...

> I tried to make some modifications before merging, but fucked something up, so I merged anyway. Do you mind opening another PR with some adjustments?
> 
> On Windows, due to the dialog that comes up with URL, the second window.open never manifests. This also means that you can't specify to not open the file currently active in Obsidian. 

Aha - I don't have a windows machine to test on, but I would have thought that this might cause a failure on the first invocation, but would work on subsequent invocations after the user had satisfied the dialog... Are you finding that you have to address a dialog every time?

I've made a toggle for "Open file", so users should be able to find a config that works well for them. 

> For me it'd make sense if the useWorkspace was a checkable setting, transparent to the user. 

Gotcha... as I was reviewing this, I thought it was cleaner to have two separate commands; in this way it's transparent to the user in that they can set shortcuts as desired 👍

For me, it's as simple as 'set my keyboard command to `open-in-vscode-via-url`', then the defaults are good. Changes I made to CLI command have been reverted, and it remains bound to the Button (this could be a setting if you think it's important).

> It'd also be nice if you could use the `{{}}` variables in the the URL workspace path setting.

Done! (for `{{vaultpath}}` - the URL protocol is not as flexible as the CLI, so `filepath` doesn't make sense in this context, I think, as we have a toggle for this purpose)

Hope that helps - let me know what you think, Tim

![screenshot - 2022-06-21 - test vault - Obsidian v0 15 2 - 2022-06-21 at 21 48](https://user-images.githubusercontent.com/218044/174792495-c52070dc-3995-45e2-a3d7-c20088ffa45c.png)

