### PR TITLE
feat: show "Open in VS Code" entry in Notebook Navigator context menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use VS Code for various purposes with your vault, such as for git versio
 Context menu in file navigation.  
 ![context menu](https://github.com/user-attachments/assets/a3ba9046-2263-41cf-bdc5-706b95484aba)
 
-The context menu entry also appears in [Notebook Navigator](https://github.com/johansan/notebook-navigator) — on both files and folders — when that plugin is installed. Notebook Navigator builds its own menus and does not fire Obsidian's native `file-menu` event, so the entry is registered through its [menu API](https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md) instead. It honours the same context menu setting and does nothing when Notebook Navigator is not present.
+The context menu entry also appears in [Notebook Navigator](https://github.com/johansan/notebook-navigator), on both files and folders, when that plugin is installed ([implementation](src/notebook-navigator.ts)).
 
 The icons work with light and dark mode.
 

--- a/README.md
+++ b/README.md
@@ -101,5 +101,6 @@ If you like this plugin you can sponsor me here on GitHub: [![Sponsor NomarCub](
 - [UseURL: open file in workspace](https://github.com/NomarCub/obsidian-open-vscode/pull/5) [feature](https://github.com/NomarCub/obsidian-open-vscode/pull/7) and restructure by [Tim Osborn](https://github.com/ptim).
 - [Go to line support](https://github.com/NomarCub/obsidian-open-vscode/pull/13) by [Moy](https://github.com/Moyf).
 - [File explorer context menu](https://github.com/NomarCub/obsidian-open-vscode/pull/15) by [Quinn McHugh](https://github.com/quinn-p-mchugh).
+- [Notebook Navigator integration](https://github.com/NomarCub/obsidian-open-vscode/pull/32) by [sbstnslg](https://github.com/sbstnslg).
 
 Thank you to the makers of the [DEVONlink](https://github.com/ryanjamurphy/DEVONlink-obsidian) plugin, as it was a great starting point for working with ribbon icons in Obsidian.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can use VS Code for various purposes with your vault, such as for git versio
 Context menu in file navigation.  
 ![context menu](https://github.com/user-attachments/assets/a3ba9046-2263-41cf-bdc5-706b95484aba)
 
+The context menu entry also appears in [Notebook Navigator](https://github.com/johansan/notebook-navigator) — on both files and folders — when that plugin is installed. Notebook Navigator builds its own menus and does not fire Obsidian's native `file-menu` event, so the entry is registered through its [menu API](https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md) instead. It honours the same context menu setting and does nothing when Notebook Navigator is not present.
+
 The icons work with light and dark mode.
 
 ![light and dark](https://user-images.githubusercontent.com/5298006/125868293-96c6f541-0604-4238-9fc3-05ff6c2e08df.gif)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use VS Code for various purposes with your vault, such as for git versio
 Context menu in file navigation.  
 ![context menu](https://github.com/user-attachments/assets/a3ba9046-2263-41cf-bdc5-706b95484aba)
 
-The context menu entry also appears in [Notebook Navigator](https://github.com/johansan/notebook-navigator), on both files and folders, when that plugin is installed ([implementation](src/notebook-navigator.ts)).
+The context menu entry also appears in [Notebook Navigator](https://github.com/johansan/notebook-navigator), on both files and folders, when that plugin is installed (see [implementation details](src/notebook-navigator.ts)).
 
 The icons work with light and dark mode.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "open-vscode",
   "name": "Open vault in VS Code",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "minAppVersion": "1.12.3",
   "description": "Open the vault as a Visual Studio Code (VS Code / VSCode) workspace with a ribbon button, a command or a file explorer context menu.",
   "author": "NomarCub",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-vscode",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-vscode",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,26 @@
       "version": "1.4.3",
       "license": "MIT",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.15",
+        "@biomejs/biome": "^2.4.16",
         "@eslint/js": "^9.39.4",
         "@types/node": "~22.18.0",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "eslint-plugin-obsidianmd": "^0.1.9",
         "obsidian": "1.12.3",
-        "obsidian-typings": "6.6.0",
+        "obsidian-typings": "6.13.0",
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.4"
+        "typescript-eslint": "^8.61.0"
       },
       "engines": {
         "node": ">=22.18"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
-      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -42,20 +42,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.15",
-        "@biomejs/cli-darwin-x64": "2.4.15",
-        "@biomejs/cli-linux-arm64": "2.4.15",
-        "@biomejs/cli-linux-arm64-musl": "2.4.15",
-        "@biomejs/cli-linux-x64": "2.4.15",
-        "@biomejs/cli-linux-x64-musl": "2.4.15",
-        "@biomejs/cli-win32-arm64": "2.4.15",
-        "@biomejs/cli-win32-x64": "2.4.15"
+        "@biomejs/cli-darwin-arm64": "2.4.16",
+        "@biomejs/cli-darwin-x64": "2.4.16",
+        "@biomejs/cli-linux-arm64": "2.4.16",
+        "@biomejs/cli-linux-arm64-musl": "2.4.16",
+        "@biomejs/cli-linux-x64": "2.4.16",
+        "@biomejs/cli-linux-x64-musl": "2.4.16",
+        "@biomejs/cli-win32-arm64": "2.4.16",
+        "@biomejs/cli-win32-x64": "2.4.16"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
-      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
       "cpu": [
         "arm64"
       ],
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
-      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
       "cpu": [
         "x64"
       ],
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
-      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
-      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
-      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
       "cpu": [
         "x64"
       ],
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
-      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
-      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
       "cpu": [
         "arm64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
-      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
       "cpu": [
         "x64"
       ],
@@ -940,9 +940,9 @@
       }
     },
     "node_modules/@obsidian-typings/obsidian-public-1.12.7": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@obsidian-typings/obsidian-public-1.12.7/-/obsidian-public-1.12.7-6.7.0.tgz",
-      "integrity": "sha512-rCRXX2p9nZpY9DZKSmvcprUolZAuaYGosPUX7oNJRZIMJsDOc8FReYrqOV5smT+mLnf+0RxbnvG9mbvmPg+XBQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@obsidian-typings/obsidian-public-1.12.7/-/obsidian-public-1.12.7-6.15.0.tgz",
+      "integrity": "sha512-H1gITV9gh2ky6TTyh82Plqu5aSPUNumg99Y9oNKZDn0rvF8j6Cbx62uAcBeAbtl7FdR1Iqe8bdrfnQSqev56BA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -950,13 +950,13 @@
       }
     },
     "node_modules/@obsidian-typings/obsidian-public-latest": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@obsidian-typings/obsidian-public-latest/-/obsidian-public-latest-6.6.0.tgz",
-      "integrity": "sha512-1Ox4ngRcJ+FKR/z1do+TMq8iIPMNFE7BxscImLqMT67d5ZWzSurMV1AfPw/gPJK1bfH3VHTafKVR8uDIgx8tIQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@obsidian-typings/obsidian-public-latest/-/obsidian-public-latest-6.13.0.tgz",
+      "integrity": "sha512-F8SWoVCNiZnaeLAorMslHscBVTePYOzawsYYK3sjN9meS2kX1J6FilLmqgOb0mqNzE5Zr/wbZ5c/ddDw19818A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@obsidian-typings/obsidian-public-1.12.7": "^6.7.0"
+        "@obsidian-typings/obsidian-public-1.12.7": "^6.15.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1042,17 +1042,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
-      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.4",
-        "@typescript-eslint/type-utils": "8.59.4",
-        "@typescript-eslint/utils": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1065,7 +1065,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.4",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1081,16 +1081,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
-      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.4",
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/typescript-estree": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1106,14 +1106,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
-      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.4",
-        "@typescript-eslint/types": "^8.59.4",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1128,14 +1128,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
-      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1146,9 +1146,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
-      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1163,15 +1163,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
-      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/typescript-estree": "8.59.4",
-        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1188,9 +1188,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
-      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1202,16 +1202,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
-      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.4",
-        "@typescript-eslint/tsconfig-utils": "8.59.4",
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1269,16 +1269,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
-      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.4",
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/typescript-estree": "8.59.4"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1293,13 +1293,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
-      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4038,13 +4038,13 @@
       }
     },
     "node_modules/obsidian-typings": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-6.6.0.tgz",
-      "integrity": "sha512-A7RROO1awG1jDBhMFzHlAD9jTqniZ2My1vmG6OSoDvdUC3YvqutTxi07b1znxQezRyPl2qCPxuNTNj4iOaIkfQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-6.13.0.tgz",
+      "integrity": "sha512-Gphh/HVdNHGhUQodlbpe9GJVUIfpKw7JA0/C2AEgPO5VTl/fb07S3IKpFg2i3/oVtTv08aH0c7wGn1HGVihBjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@obsidian-typings/obsidian-public-latest": "^6.6.0"
+        "@obsidian-typings/obsidian-public-latest": "^6.13.0"
       }
     },
     "node_modules/optionator": {
@@ -4780,9 +4780,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4977,16 +4977,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
-      "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.4",
-        "@typescript-eslint/parser": "8.59.4",
-        "@typescript-eslint/typescript-estree": "8.59.4",
-        "@typescript-eslint/utils": "8.59.4"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-vscode",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Open vault in Visual Studio Code ribbon button and command for Obsidian (https://obsidian.md)",
   "main": "main.js",
   "author": "NomarCub",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "version": "node version-bump.mts"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "^2.4.16",
     "@eslint/js": "^9.39.4",
     "@types/node": "~22.18.0",
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "eslint-plugin-obsidianmd": "^0.1.9",
     "obsidian": "1.12.3",
-    "obsidian-typings": "6.6.0",
+    "obsidian-typings": "6.13.0",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.4"
+    "typescript-eslint": "^8.61.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,8 +57,7 @@ export default class OpenVSCode extends Plugin {
 
         this.registerEvent(this.app.workspace.on("file-menu", this.fileMenuHandler.bind(this)));
 
-        // Notebook Navigator builds its own menus and does not fire "file-menu",
-        // so register the same entry through its public API when it is present.
+        // Notebook Navigator community plugin integration
         registerNotebookNavigatorMenus(this, OpenVSCode.iconId);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
     type TAbstractFile,
 } from "obsidian";
 import type {} from "obsidian-typings";
+import { registerNotebookNavigatorMenus } from "./notebook-navigator.ts";
 import { DEFAULT_SETTINGS, type OpenVSCodeSettings, OpenVSCodeSettingsTab } from "./settings.ts";
 
 export default class OpenVSCode extends Plugin {
@@ -55,6 +56,10 @@ export default class OpenVSCode extends Plugin {
         });
 
         this.registerEvent(this.app.workspace.on("file-menu", this.fileMenuHandler.bind(this)));
+
+        // Notebook Navigator builds its own menus and does not fire "file-menu",
+        // so register the same entry through its public API when it is present.
+        registerNotebookNavigatorMenus(this, OpenVSCode.iconId);
     }
 
     openVSCode(file: TAbstractFile | null = this.app.workspace.getActiveFile()): void {

--- a/src/notebook-navigator.ts
+++ b/src/notebook-navigator.ts
@@ -2,11 +2,10 @@ import type { MenuItem, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
 import type OpenVSCode from "./main.ts";
 
 /*
- * Notebook Navigator builds its own menus and does not fire Obsidian's "file-menu"
- * event, so register the same entry through its public API when present.
- *
- * Types below are the subset we use, mirrored from notebook-navigator.d.ts @ 3.1.2:
+ * Types below are the subset we use, mirrored from here:
  * https://github.com/johansan/notebook-navigator/blob/3.1.2/src/api/public/notebook-navigator.d.ts#L390-L399
+ * 
+ * See also: https://github.com/johansan/notebook-navigator/blob/3.1.2/docs/api-reference.md
  */
 
 const NOTEBOOK_NAVIGATOR_ID = "notebook-navigator";
@@ -30,7 +29,12 @@ interface NotebookNavigatorAPI {
     };
 }
 
-/** Mirrors the native "Open in VS Code" entry into Notebook Navigator's file and folder menus. */
+/**
+ * Mirrors the native "Open in VS Code" entry into Notebook Navigator's file and folder menus.
+ * 
+ * Notebook Navigator builds its own menus and does not fire Obsidian's "file-menu" event,
+ * so register the same entry through its public API when present.
+ */
 export function registerNotebookNavigatorMenus(plugin: OpenVSCode, iconId: string): void {
     plugin.app.workspace.onLayoutReady(() => {
         const nnPlugin = plugin.app.plugins.plugins[NOTEBOOK_NAVIGATOR_ID] as

--- a/src/notebook-navigator.ts
+++ b/src/notebook-navigator.ts
@@ -1,0 +1,75 @@
+import type { MenuItem, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
+import type OpenVSCode from "./main.ts";
+
+/*
+ * Integration with Notebook Navigator (https://github.com/johansan/notebook-navigator).
+ *
+ * Notebook Navigator (NN) is a popular file explorer replacement. It builds its own
+ * context menus and intentionally does not fire Obsidian's native "file-menu" event,
+ * so the entry added in `fileMenuHandler` never shows up there. Instead, NN exposes a
+ * public API that lets plugins register items directly into its menus.
+ *
+ * API reference: https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md
+ *
+ * Only the small part of the API used here is typed.
+ */
+
+const NOTEBOOK_NAVIGATOR_ID = "notebook-navigator";
+
+type AddItem = (cb: (item: MenuItem) => void) => void;
+
+interface NotebookNavigatorApi {
+    menus?: {
+        // Both available since Notebook Navigator 1.2.0.
+        registerFolderMenu?: (
+            callback: (context: { addItem: AddItem; folder: TFolder }) => void,
+        ) => () => void;
+        registerFileMenu?: (callback: (context: { addItem: AddItem; file: TFile }) => void) => () => void;
+    };
+}
+
+/**
+ * Mirrors the native "Open in VS Code" file explorer entry (see `fileMenuHandler`)
+ * into Notebook Navigator's file and folder context menus via its public API.
+ *
+ * Does nothing if Notebook Navigator is not installed or its API is unavailable.
+ * The menu items honour the same `showFileContextMenuItem` setting as the native entry.
+ */
+export function registerNotebookNavigatorMenus(plugin: OpenVSCode, iconId: string): void {
+    // Wait for layout ready so Notebook Navigator has loaded and exposed its API.
+    plugin.app.workspace.onLayoutReady(() => {
+        const nnPlugin = plugin.app.plugins.plugins[NOTEBOOK_NAVIGATOR_ID] as
+            | (Plugin & { api?: NotebookNavigatorApi })
+            | undefined;
+        const menus = nnPlugin?.api?.menus;
+        if (!menus) return;
+
+        const addOpenItem = (item: MenuItem, file: TAbstractFile): void => {
+            item.setTitle("Open in VS Code")
+                .setIcon(iconId)
+                .onClick(() => {
+                    plugin.openVSCode(file);
+                });
+        };
+
+        if (menus.registerFolderMenu) {
+            const dispose = menus.registerFolderMenu(({ addItem, folder }) => {
+                if (!plugin.settings.showFileContextMenuItem) return;
+                addItem((item) => {
+                    addOpenItem(item, folder);
+                });
+            });
+            plugin.register(dispose);
+        }
+
+        if (menus.registerFileMenu) {
+            const dispose = menus.registerFileMenu(({ addItem, file }) => {
+                if (!plugin.settings.showFileContextMenuItem) return;
+                addItem((item) => {
+                    addOpenItem(item, file);
+                });
+            });
+            plugin.register(dispose);
+        }
+    });
+}

--- a/src/notebook-navigator.ts
+++ b/src/notebook-navigator.ts
@@ -4,7 +4,7 @@ import type OpenVSCode from "./main.ts";
 /*
  * Types below are the subset we use, mirrored from here:
  * https://github.com/johansan/notebook-navigator/blob/3.1.2/src/api/public/notebook-navigator.d.ts#L390-L399
- * 
+ *
  * See also: https://github.com/johansan/notebook-navigator/blob/3.1.2/docs/api-reference.md
  */
 
@@ -31,7 +31,7 @@ interface NotebookNavigatorAPI {
 
 /**
  * Mirrors the native "Open in VS Code" entry into Notebook Navigator's file and folder menus.
- * 
+ *
  * Notebook Navigator builds its own menus and does not fire Obsidian's "file-menu" event,
  * so register the same entry through its public API when present.
  */

--- a/src/notebook-navigator.ts
+++ b/src/notebook-navigator.ts
@@ -2,44 +2,39 @@ import type { MenuItem, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
 import type OpenVSCode from "./main.ts";
 
 /*
- * Integration with Notebook Navigator (https://github.com/johansan/notebook-navigator).
+ * Notebook Navigator builds its own menus and does not fire Obsidian's "file-menu"
+ * event, so register the same entry through its public API when present.
  *
- * Notebook Navigator (NN) is a popular file explorer replacement. It builds its own
- * context menus and intentionally does not fire Obsidian's native "file-menu" event,
- * so the entry added in `fileMenuHandler` never shows up there. Instead, NN exposes a
- * public API that lets plugins register items directly into its menus.
- *
- * API reference: https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md
- *
- * Only the small part of the API used here is typed.
+ * Types below are the subset we use, mirrored from notebook-navigator.d.ts @ 3.1.2:
+ * https://github.com/johansan/notebook-navigator/blob/3.1.2/src/api/public/notebook-navigator.d.ts#L390-L399
  */
 
 const NOTEBOOK_NAVIGATOR_ID = "notebook-navigator";
 
-type AddItem = (cb: (item: MenuItem) => void) => void;
+interface FileMenuExtensionContext {
+    addItem(cb: (item: MenuItem) => void): void;
+    file: TFile;
+}
 
-interface NotebookNavigatorApi {
-    menus?: {
-        // Both available since Notebook Navigator 1.2.0.
-        registerFolderMenu?: (
-            callback: (context: { addItem: AddItem; folder: TFolder }) => void,
-        ) => () => void;
-        registerFileMenu?: (callback: (context: { addItem: AddItem; file: TFile }) => void) => () => void;
+interface FolderMenuExtensionContext {
+    addItem(cb: (item: MenuItem) => void): void;
+    folder: TFolder;
+}
+
+type MenuExtensionDispose = () => void;
+
+interface NotebookNavigatorAPI {
+    menus: {
+        registerFileMenu(callback: (context: FileMenuExtensionContext) => void): MenuExtensionDispose;
+        registerFolderMenu(callback: (context: FolderMenuExtensionContext) => void): MenuExtensionDispose;
     };
 }
 
-/**
- * Mirrors the native "Open in VS Code" file explorer entry (see `fileMenuHandler`)
- * into Notebook Navigator's file and folder context menus via its public API.
- *
- * Does nothing if Notebook Navigator is not installed or its API is unavailable.
- * The menu items honour the same `showFileContextMenuItem` setting as the native entry.
- */
+/** Mirrors the native "Open in VS Code" entry into Notebook Navigator's file and folder menus. */
 export function registerNotebookNavigatorMenus(plugin: OpenVSCode, iconId: string): void {
-    // Wait for layout ready so Notebook Navigator has loaded and exposed its API.
     plugin.app.workspace.onLayoutReady(() => {
         const nnPlugin = plugin.app.plugins.plugins[NOTEBOOK_NAVIGATOR_ID] as
-            | (Plugin & { api?: NotebookNavigatorApi })
+            | (Plugin & { api?: NotebookNavigatorAPI })
             | undefined;
         const menus = nnPlugin?.api?.menus;
         if (!menus) return;
@@ -52,24 +47,21 @@ export function registerNotebookNavigatorMenus(plugin: OpenVSCode, iconId: strin
                 });
         };
 
-        if (menus.registerFolderMenu) {
-            const dispose = menus.registerFolderMenu(({ addItem, folder }) => {
+        plugin.register(
+            menus.registerFileMenu((context) => {
                 if (!plugin.settings.showFileContextMenuItem) return;
-                addItem((item) => {
-                    addOpenItem(item, folder);
+                context.addItem((item) => {
+                    addOpenItem(item, context.file);
                 });
-            });
-            plugin.register(dispose);
-        }
-
-        if (menus.registerFileMenu) {
-            const dispose = menus.registerFileMenu(({ addItem, file }) => {
+            }),
+        );
+        plugin.register(
+            menus.registerFolderMenu((context) => {
                 if (!plugin.settings.showFileContextMenuItem) return;
-                addItem((item) => {
-                    addOpenItem(item, file);
+                context.addItem((item) => {
+                    addOpenItem(item, context.folder);
                 });
-            });
-            plugin.register(dispose);
-        }
+            }),
+        );
     });
 }


### PR DESCRIPTION
Closes #31.

[Notebook Navigator](https://github.com/johansan/notebook-navigator) (NN) builds its own context menus and intentionally does not fire Obsidian's native `file-menu` event, so the "Open in VS Code" entry from `fileMenuHandler` never appears there. NN instead exposes a [public menu API](https://github.com/johansan/notebook-navigator/blob/main/docs/api-reference.md) for plugins to register their own items.

This PR registers the same action through that API when NN is present, for **both files and folders** (`registerFolderMenu` / `registerFileMenu`, available since NN 1.2.0).

### Notes

- Reuses the existing `openVSCode()` path, so all current settings/templates (the `code` command, `vscode://` URL, line/column) work unchanged.
- Honours the existing **"Display Open in VS Code option for files/folders"** (`showFileContextMenuItem`) setting — no new setting added, no extra menu clutter.
- Disposes the registrations cleanly on unload and is a complete no-op when NN isn't installed, so it has zero effect for users who don't use it.
- All NN-specific code is isolated in a new `src/notebook-navigator.ts`; `main.ts` only gains an import and one call in `onload`.

`npm run check` (type-check + lint + format) passes and the build succeeds.

This also answers the folder-menu question from #31: NN's API does expose `registerFolderMenu`, so right-clicking a folder → "Open in VS Code" works as well.
